### PR TITLE
Fix unescape_map in parse_helper for elixir 1.6

### DIFF
--- a/lib/rdf/serialization/parse_helper.ex
+++ b/lib/rdf/serialization/parse_helper.ex
@@ -77,9 +77,11 @@ defmodule RDF.Serialization.ParseHelper do
   defp string_unescape_map(?r),  do: ?\r
   defp string_unescape_map(?t),  do: ?\t
   defp string_unescape_map(?u),  do: true
+  defp string_unescape_map(:unicode),  do: true
   defp string_unescape_map(e),   do: e
 
   defp iri_unescape_map(?u),  do: true
+  defp iri_unescape_map(:unicode),  do: true
   defp iri_unescape_map(e),   do: e
 
   def unescape_8digit_unicode_seq(string) do


### PR DESCRIPTION
46 tests were failing when using Elixir 1.6.0 with the following error:

```
46) test Positive syntax test: literal_with_numeric_escape4.nt (RDF.NTriples.W3C.TestSuite)
     test/acceptance/ntriples_w3c_test.exs:24
     ** (CaseClauseError) no case clause matching: :unicode
     code: assert {:ok, %RDF.Graph{}} = RDF.NTriples.read_file(context.registered.nt_test[:file])
     stacktrace:
       (elixir) src/elixir_interpolation.erl:101: :elixir_interpolation.unescape_chars/3
       (rdf) lib/rdf/serialization/parse_helper.ex:38: RDF.Serialization.ParseHelper.to_literal/1
       (rdf) src/ntriples_parser.yrl:34: :ntriples_parser.yeccpars2_17/7
       (rdf) .../erlang/20.2.2/lib/parsetools-2.1.6/include/yeccpre.hrl:57: :ntriples_parser.yeccpars0/5
       (rdf) lib/rdf/serializations/ntriples_decoder.ex:8: RDF.NTriples.Decoder.decode/2
       test/acceptance/ntriples_w3c_test.exs:25: (test)
```

Elixir 1.6 changed the pattern match for unicode in unescape_string from ?u to :unicode. The change can be seen in the [Elixir 1.6.0 docs](https://hexdocs.pm/elixir/Macro.html#unescape_string/2) vs the [1.5.3 docs](https://hexdocs.pm/elixir/1.5.3/Macro.html#unescape_string/2). This adds the additional match for :unicode and preserves the older ?u matching. I ran all tests in Elixir 1.6.0 and 1.5.3 and all passed.

Great work on this project. I have been using it and it is working well!